### PR TITLE
Speed up 'docker build'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,18 @@ RUN apt-get update \
     flex bison \
     git \
     wget \
+    unzip \
     gcc-aarch64-linux-gnu
 
 RUN mkdir -p /data/output
 WORKDIR /data
-RUN git clone https://github.com/u-boot/u-boot
-RUN git clone https://github.com/raspberrypi/firmware
+RUN wget --quiet https://github.com/u-boot/u-boot/archive/refs/heads/master.zip
+RUN unzip -q master.zip
+RUN rm master.zip
+RUN mv u-boot-master u-boot
+RUN wget --quiet https://github.com/raspberrypi/firmware/archive/refs/heads/master.zip
+RUN unzip -q master.zip
+RUN mv firmware-master firmware
 COPY entrypoint.sh /data/entrypoint.sh
 RUN apt-get -y install \
     autopoint \


### PR DESCRIPTION
Use wget to download u-boot and firmware github repos.

This dramatically speeds up the build process as it skips
downloading the multi-gigabyte firmware history. It also
needs far less memory.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>